### PR TITLE
Issue #694 fix unit tests post MDL-78806

### DIFF
--- a/tests/unit/classes/view/turnitintooltwo_view_test.php
+++ b/tests/unit/classes/view/turnitintooltwo_view_test.php
@@ -53,7 +53,7 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
         $turnitintooltwoview->output_header($pageurl, $pagetitle, $pageheading, true);
 
         $this->assertStringContainsString($pageurl, (string)$PAGE->url);
-        $this->assertEquals($pagetitle, $PAGE->title);
+        $this->assertStringContainsString($pagetitle, $PAGE->title);
         $this->assertEquals($pageheading, $PAGE->heading);
     }
 


### PR DESCRIPTION
```
❯ ctrl test --filter mod_turnitintooltwo
Moodle 4.1.5+ (Build: 20230915), d50a227cc02b3b84aa6d2e54f4f9aa09c6060aef
Php: 8.0.29, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 5.19.0-50-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

..................................................                50 / 50 (100%)

Time: 00:03.306, Memory: 394.00 MB

OK (50 tests, 248 assertions)
```


Previous:
```
❯ ctrl test --filter mod_turnitintooltwo_view_testcase::test_output_header
Moodle 4.1.5+ (Build: 20230915), d50a227cc02b3b84aa6d2e54f4f9aa09c6060aef
Php: 8.0.29, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 5.19.0-50-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 00:00.512, Memory: 372.00 MB

There was 1 failure:

1) mod_turnitintooltwo_view_testcase::test_output_header
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Fake Title'
+'Fake Title | phpunit'

mod/turnitintooltwo/tests/unit/classes/view/turnitintooltwo_view_test.php:56
lib/phpunit/classes/advanced_testcase.php:80

FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
