### PR TITLE
Fix icons not rendering in mod_form for catawesome theme

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -144,10 +144,17 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
                                                         "href" => $CFG->wwwroot."/mod/turnitintooltwo/styles.css"));
         $script .= html_writer::tag('link', '', array("rel" => "stylesheet", "type" => "text/css",
                                                         "href" => $CFG->wwwroot."/mod/turnitintooltwo/css/colorbox.css"));
-        $script .= html_writer::tag('link', '', array("rel" => "stylesheet", "type" => "text/css",
-                                                        "href" => $CFG->wwwroot."/mod/turnitintooltwo/css/tii-icon-webfont.css"));
-        $script .= html_writer::tag('link', '', array("rel" => "stylesheet", "type" => "text/css",
-                                                        "href" => $CFG->wwwroot."/mod/turnitintooltwo/css/font-awesome.min.css"));
+
+        // The following iconsets are already provided by the catawesome theme.
+        // If the following scripts load with this theme enabled, icons do not render.
+        if (!get_config('core', 'theme') == 'catawesome') {
+            $script .= html_writer::tag('link', '',
+                array("rel" => "stylesheet", "type" => "text/css",
+                "href" => $CFG->wwwroot."/mod/turnitintooltwo/css/tii-icon-webfont.css"));
+            $script .= html_writer::tag('link', '',
+                array("rel" => "stylesheet", "type" => "text/css",
+                "href" => $CFG->wwwroot."/mod/turnitintooltwo/css/font-awesome.min.css"));
+        }
 
         $mform->addElement('html', $script);
 

--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -67,10 +67,14 @@ class turnitintooltwo_view {
         $PAGE->requires->css($cssurl);
         $cssurl = new moodle_url('/mod/turnitintooltwo/css/jquery-ui-1.8.4.custom.css');
         $PAGE->requires->css($cssurl);
-        $cssurl = new moodle_url('/mod/turnitintooltwo/css/font-awesome.min.css');
-        $PAGE->requires->css($cssurl);
-        $cssurl = new moodle_url('/mod/turnitintooltwo/css/tii-icon-webfont.css');
-        $PAGE->requires->css($cssurl);
+
+        // Include this CSS if not using theme_catawesome is not used.
+        if (!get_config('core', 'theme') == 'catawesome') {
+            $cssurl = new moodle_url('/mod/turnitintooltwo/css/font-awesome.min.css');
+            $PAGE->requires->css($cssurl);
+            $cssurl = new moodle_url('/mod/turnitintooltwo/css/tii-icon-webfont.css');
+            $PAGE->requires->css($cssurl);
+        }
 
         // Include JS.
         $PAGE->requires->jquery();


### PR DESCRIPTION
**Description:** When using the a theme (i.e catawesome) that implements the same icons as this plugin, these icons are not properly rendered (see below). 

![image](https://github.com/catalyst/moodle-mod_turnitintooltwo/assets/65814885/2e0cedd3-c152-43b8-90a0-fcbdc4fad7c6)

This PR fixes this by conditionally using this plugin's scripts.

![image](https://github.com/catalyst/moodle-mod_turnitintooltwo/assets/65814885/a3baccf9-dc48-4204-8e31-d0a617570a43)

This was tested on sites with and without the catawesome theme. Plugin functionality remains the same in both cases

