### PR TITLE
Revert "PHP 8.1 deprecation changes"

### DIFF
--- a/sdk/soap.class.php
+++ b/sdk/soap.class.php
@@ -283,7 +283,8 @@ class Soap extends SoapClient {
         parent::__construct( $wsdl, $options );
     }
 
-    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string {
+    public function __doRequest($request, $location, $action, $version, $one_way = null): ?string {
+
         $http_headers = array(
             'Content-type: text/xml;charset="utf-8"',
             'Accept: text/xml',


### PR DESCRIPTION
This reverts commit bfe8a638931455168b1bd86babf447c2e316ccdd.

```
Warning: Declaration of Soap::__doRequest(string $request, string $location, string $action, int $version, ?bool $one_way = NULL): ?string should be compatible with SoapClient::__doRequest($request, $location, $action, $version, $one_way = NULL) in /mod/turnitintooltwo/sdk/soap.class.php on line 286
```
- Reverted the __doRequest method signature in Soap class to maintain compatibility with SoapClient in PHP 7.4