### PR TITLE
Fix deprecation issue

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -251,7 +251,7 @@ function turnitintooltwo_grade_item_update($turnitintooltwo, $grades = null) {
 
     // Get the latest part, for the post date and set the default hidden value on grade item.
     $lastpart = $DB->get_record('turnitintooltwo_parts', array('turnitintooltwoid' => $turnitintooltwo->id), 'max(dtpost)');
-    $lastpart = current($lastpart);
+    $lastpart = current((array)$lastpart);
     $params['hidden'] = $lastpart;
 
     // There should always be a $cm unless this is called on module creation.

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1862,20 +1862,21 @@ class turnitintooltwo_assignment {
         }
 
         foreach ($submissions as $submission) {
-            if (!is_nan($submission->submission_grade) AND (!empty($submission->submission_gmimaged) || $istutor)
-                    AND !is_null($submission->submission_grade) AND $weightarray[$submission->submission_part] != 0) {
+            if (isset($submission->submission_grade) && !is_nan($submission->submission_grade)
+                && (!empty($submission->submission_gmimaged) || $istutor)
+                && !is_null($submission->submission_grade) && $weightarray[$submission->submission_part] != 0) {
                 $weightedgrade = $submission->submission_grade / $weightarray[$submission->submission_part];
                 $overallgrade += $weightedgrade * ($weightarray[$submission->submission_part] / $overallweight) * $maxgrade;
             }
         }
 
-        if (!is_null($overallgrade) AND $this->turnitintooltwo->grade < 0) {
+        if (!is_null($overallgrade) && $this->turnitintooltwo->grade < 0) {
             return ($overallgrade == 0) ? 1 : ceil($overallgrade);
         } else {
             if (is_null($overallgrade)) {
                 return "--";
             }
-            return (!is_nan($overallgrade) AND !is_null($overallgrade)) ? number_format($overallgrade, 2) : '--';
+            return (!is_nan($overallgrade) && !is_null($overallgrade)) ? number_format($overallgrade, 2) : '--';
         }
     }
 


### PR DESCRIPTION
**The issue**
We just came across a very difficult chain to track down:
1. `ajax.php` was 503'ing for a given assignment part. No exceptions output, nothing relevant in the error log.
2. We found if we added `error_log` to the script, it would magically start working and not 503.
3. After a lot of digging, we found that one of the submissions returned from the API had a `null` grade, which php would pass to `is_nan(null)` which would output a deprecation message.

I believe that the deprecation message being output was causing somewhere upstream (fpm, nginx, etc...) to freak out and die giving the 503 because it was expecting json.

**The fix**
TII has fixed this upstream in their develop branch (not their master, so it wasn't merged in here yet), so I just cherry picked those commits. This fixes it because `isset()` will return false if it is null, and php will exit the condition early (it will never evaluate `is_nan` if `!isset`)

Also cherry picked the other deprecation fixing commits from the upstream PR.