### PR TITLE
Declare properties

### DIFF
--- a/sdk/oauthsimple.class.php
+++ b/sdk/oauthsimple.class.php
@@ -18,6 +18,11 @@ class OAuthSimple {
     protected $_default_signature_method;
     protected $_action;
     protected $_nonce_chars;
+    protected $_parameters;
+    protected $_path;
+    protected $oauth_body_hash;
+    protected $sbs;
+    protected $path;
 
     /**
      * Constructor

--- a/settings.php
+++ b/settings.php
@@ -115,11 +115,11 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configtext_int_only('turnitintooltwo/accountid',
                                                     get_string("turnitinaccountid", "turnitintooltwo"),
-                                                    get_string("turnitinaccountid_desc", "turnitintooltwo"), ''));
+                                                    get_string("turnitinaccountid_desc", "turnitintooltwo"), 0));
 
     $settings->add(new admin_setting_config_tii_secret_key('turnitintooltwo/secretkey',
                                                         get_string("turnitinsecretkey", "turnitintooltwo"),
-                                                        get_string("turnitinsecretkey_desc", "turnitintooltwo"), '', 'PARAM_TEXT'));
+                                                        get_string("turnitinsecretkey_desc", "turnitintooltwo"), ''));
 
     $testoptions = array(
         'https://api.turnitin.com' => 'https://api.turnitin.com',
@@ -137,7 +137,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configselect('turnitintooltwo/apiurl',
                                     get_string("turnitinapiurl", "turnitintooltwo"),
                                     get_string("turnitinapiurl_desc", "turnitintooltwo").$offlinecomment.$testconnection,
-                                    0, $testoptions));
+                                    'https://api.turnitin.com', $testoptions));
 
     // Miscellaneous settings.
     $settings->add(new admin_setting_heading('turnitintooltwo_debugginglogs',

--- a/settingslib.php
+++ b/settingslib.php
@@ -78,7 +78,7 @@ class admin_setting_config_tii_secret_key extends admin_setting_configpasswordun
         }
 
         $cleaned = clean_param($data, $this->paramtype);
-        if ("$data" === "$cleaned" && strlen($data) > 0) { // Implicit conversion to string is needed to do exact comparison.
+        if ("$data" === "$cleaned") { // Implicit conversion to string is needed to do exact comparison.
             return true;
         } else {
             return get_string('validateerror', 'admin');

--- a/tests/unit/classes/privacy/provider_test.php
+++ b/tests/unit/classes/privacy/provider_test.php
@@ -38,6 +38,14 @@ if (!class_exists('\core_privacy\tests\provider_testcase')) {
 
 class mod_turnitintooltwo_privacy_provider_testcase extends \core_privacy\tests\provider_testcase {
 
+    private $testcase;
+    private $turnitintooltwoassignment;
+    private $cm;
+    private $parts;
+    private $student1;
+    private $studentrole;
+    private $student2;
+
     public function setUp(): void {
         global $DB;
 

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -860,8 +860,11 @@ class turnitintooltwo_assignment {
 
         $properties = new stdClass();
         $properties->name = $this->turnitintooltwo->name . ' - ' . $partname;
-        $intro = strip_pluginfile_content($this->turnitintooltwo->intro);
-        $intro = preg_replace("/<img[^>]+\>/i", "", $intro);
+        $intro = $this->turnitintooltwo->intro;
+        if (!empty($intro)) {
+            $intro = strip_pluginfile_content($intro);
+            $intro = preg_replace("/<img[^>]+\>/i", "", $intro);
+        }
         $properties->description = ($intro == null) ? '' : $intro;
         $properties->courseid = $this->turnitintooltwo->course;
         $properties->groupid = 0;

--- a/turnitintooltwo_submission.class.php
+++ b/turnitintooltwo_submission.class.php
@@ -51,6 +51,7 @@ class turnitintooltwo_submission {
     public $submission_acceptnothing;
     public $overallgrade;
     private $receipt;
+    private $instructor_receipt;
 
     public function __construct($id = 0, $idtype = "moodle", $turnitintooltwoassignment = "", $partid = "") {
         $this->receipt = new receipt_message();

--- a/turnitintooltwo_submission.class.php
+++ b/turnitintooltwo_submission.class.php
@@ -82,7 +82,7 @@ class turnitintooltwo_submission {
         $this->submission_part = $data['submissionpart'];
         $this->submission_title = $data['submissiontitle'];
         $this->submission_objectid = null;
-        $this->submissionunanon = 0;
+        $this->submission_unanon = 0;
 
         $submission = new stdClass();
         $submission->userid = $data['studentsname'];


### PR DESCRIPTION
Fix some declaration error for `master` branch
Cherry pick from `master-catalyst` branch

```
# delcare test suite properties for php 8.3
git cherry-pick 15f494a908f4b6e662c2b7427330155200365303
# Fix variable name
git cherry-pick 3f6e8d5fb2f3ef5dade8c5ceebf390eac93a8609
# Another missing property
git cherry-pick 42e6770b7de13b8237ca0296ccd4dd7247516456
# Add more missing properties
git cherry-pick 16560beaceecfd7d35ad2a90f23d8960697074d1
# fix turnitin#779 fix turnitin#723 update default value for settings
git cherry-pick 74c0056c84398799de80c668293351930eeb794d
# Only clean intro if not empty
git cherry-pick 8e71ced8f024b95314dc4d00fc9b577b9c356cbd
# OR https://github.com/turnitin/moodle-mod_turnitintooltwo/commit/fcb112a4c46723c5883ded98591708f23988ff06 is better?
```